### PR TITLE
chore: improve requests cache tests

### DIFF
--- a/leaktopus_backend/conftest.py
+++ b/leaktopus_backend/conftest.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-
+import requests
 from leaktopus.app import create_app
 from leaktopus.domain.extractors.domain_extractor import DomainExtractor
 from leaktopus.domain.extractors.email_extractor import EmailExtractor
@@ -32,6 +32,7 @@ from leaktopus.tasks.task_manager import TaskManager
 @pytest.fixture()
 def app():
     task_manager = TaskManager(MemoryClient(override_tasks={"run_task": lambda: None}))
+    session = requests.Session
     app = create_app(task_manager=task_manager, settings_override={
         "TESTING": True,
         "USE_EXPERIMENTAL_REFACTORING": True,
@@ -39,11 +40,9 @@ def app():
     })
     with app.app_context():
         yield app
+    requests.Session = session
+    requests.sessions.Session = session
 
-@pytest.fixture()
-def client_memory(app):
-    with app.test_client() as client:
-        yield client
 
 @pytest.fixture()
 def app_db():

--- a/leaktopus_backend/leaktopus/requests_cache_test.py
+++ b/leaktopus_backend/leaktopus/requests_cache_test.py
@@ -4,7 +4,7 @@ from leaktopus.requests_cache import CustomCachedSessionWithPickleSupport
 from requests_cache import BaseCache
 
 
-def testRequestsCacheEnabledSuccess(app, httpserver):
+def test_requests_cache_enabled_success(app, httpserver):
     config = app.config
     config['REQUESTS_CACHE_ENABLED'] = True
     config['REQUESTS_CACHE_BACKEND'] = BaseCache()
@@ -15,7 +15,7 @@ def testRequestsCacheEnabledSuccess(app, httpserver):
     assert requests_cache.get_cache().response_count() == 1
 
 
-def testRequestsCacheDisabledSuccess(app, httpserver):
+def test_requests_cache_disabled_success(app, httpserver):
     config = app.config
     config['REQUESTS_CACHE_ENABLED'] = False
 

--- a/leaktopus_backend/leaktopus/requests_cache_test.py
+++ b/leaktopus_backend/leaktopus/requests_cache_test.py
@@ -1,28 +1,25 @@
 import requests
+import requests_cache
 from leaktopus.requests_cache import CustomCachedSessionWithPickleSupport
 from requests_cache import BaseCache
-from werkzeug import Request, Response
 
 
-def testRequestsCacheWithCacheSuccess(app, httpserver):
+def testRequestsCacheEnabledSuccess(app, httpserver):
     config = app.config
-    config['REQUESTS_CACHE_ENABLED'] = False
-
-    counter = 0
-
-    def handler(request: Request):
-        nonlocal counter
-        counter += 1
-        return Response("Hello, World!", status=200)
-
-    httpserver.expect_request("/test").respond_with_handler(handler)
-    assert requests.get(httpserver.url_for("/test")).status_code == 200
-    assert requests.get(httpserver.url_for("/test")).text == "Hello, World!"
-    assert counter == 2
-
     config['REQUESTS_CACHE_ENABLED'] = True
     config['REQUESTS_CACHE_BACKEND'] = BaseCache()
     CustomCachedSessionWithPickleSupport.register(app)
-    assert requests.get(httpserver.url_for("/test")).status_code == 200
-    assert requests.get(httpserver.url_for("/test")).text == "Hello, World!"
-    assert counter == 3
+    httpserver.expect_request("/enabled").respond_with_data("Enabled!", status=200)
+    assert requests.get(httpserver.url_for("/enabled")).status_code == 200
+    assert requests.get(httpserver.url_for("/enabled")).text == "Enabled!"
+    assert requests_cache.get_cache().response_count() == 1
+
+
+def testRequestsCacheDisabledSuccess(app, httpserver):
+    config = app.config
+    config['REQUESTS_CACHE_ENABLED'] = False
+
+    httpserver.expect_request("/disabled").respond_with_data("Disabled!", status=200)
+    assert requests.get(httpserver.url_for("/disabled")).status_code == 200
+    assert requests.get(httpserver.url_for("/disabled")).text == "Disabled!"
+    assert requests_cache.get_cache() is None


### PR DESCRIPTION
Because requests-cache uses a monkey patch solution to override `requests.Session` and `requests.sessions.Session`, we have to make sure that it is reset for every test otherwise tests that use `requests` might be affected by `requests-cache` without knowing about it. 